### PR TITLE
feat: 시장 설정/관리자 UI 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/src/api/shops.js
+++ b/src/api/shops.js
@@ -1,0 +1,5 @@
+import api from "./client";
+
+// 상점 상세(아이템 포함 응답)
+export const getShop = (marketId, shopId) =>
+  api.get(`/markets/${marketId}/shops/${shopId}`);

--- a/src/components/ModeToggle.jsx
+++ b/src/components/ModeToggle.jsx
@@ -1,0 +1,25 @@
+// src/components/ModeToggle.jsx
+export default function ModeToggle({ mode, onToggle }) {
+  const isAdmin = mode === "admin";
+  return (
+    <div className="ml-2 flex items-center gap-2">
+      <span className="text-emerald-700 font-semibold">
+        {isAdmin ? "관리자" : "사용자"}
+      </span>
+      <button
+        onClick={onToggle}
+        className={`w-10 h-5 rounded-full relative transition-colors ${
+          isAdmin ? "bg-emerald-500" : "bg-gray-300"
+        }`}
+        aria-pressed={isAdmin}
+        title="관리자/사용자 전환"
+      >
+        <span
+          className={`absolute top-0.5 left-0.5 h-4 w-4 rounded-full bg-white transition-transform ${
+            isAdmin ? "translate-x-5" : "translate-x-0"
+          }`}
+        />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useAdminMode.js
+++ b/src/hooks/useAdminMode.js
@@ -1,0 +1,23 @@
+// src/hooks/useAdminMode.js
+import { useEffect, useState } from "react";
+
+const KEY = "appMode"; // "admin" | "user"
+
+export default function useAdminMode() {
+  // 첫 마운트 시 localStorage에서 읽기
+  const [mode, setMode] = useState(() => {
+    const v = localStorage.getItem(KEY);
+    return v === "admin" || v === "user" ? v : "user";
+  });
+
+  const isAdmin = mode === "admin";
+
+  // 변경사항 저장
+  useEffect(() => {
+    localStorage.setItem(KEY, mode);
+  }, [mode]);
+
+  const toggle = () => setMode((m) => (m === "admin" ? "user" : "admin"));
+
+  return { mode, isAdmin, toggle, setMode };
+}

--- a/src/lib/kakaoMapLoader.js
+++ b/src/lib/kakaoMapLoader.js
@@ -1,0 +1,32 @@
+let kakaoPromise = null;
+
+export function loadKakaoMap() {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("window is undefined"));
+  }
+  // 이미 로드되어 있으면 그대로 반환
+  if (window.kakao && window.kakao.maps) {
+    return Promise.resolve(window.kakao);
+  }
+  // 최초 1회만 스크립트 삽입
+  if (!kakaoPromise) {
+    kakaoPromise = new Promise((resolve, reject) => {
+      const appkey = import.meta.env.VITE_KAKAO_MAP_KEY;
+      if (!appkey) {
+        reject(new Error("VITE_KAKAO_MAP_KEY is missing"));
+        return;
+      }
+      const script = document.createElement("script");
+      script.async = true;
+      script.src =
+        `https://dapi.kakao.com/v2/maps/sdk.js` +
+        `?appkey=${appkey}&libraries=services,clusterer&autoload=false`;
+      script.onload = () => {
+        window.kakao.maps.load(() => resolve(window.kakao));
+      };
+      script.onerror = () => reject(new Error("Failed to load Kakao Maps script"));
+      document.head.appendChild(script);
+    });
+  }
+  return kakaoPromise;
+}

--- a/src/pages/AddStore.jsx
+++ b/src/pages/AddStore.jsx
@@ -4,18 +4,35 @@ import SingleImageUploader from "../components/SingleImageUploader.jsx";
 
 // --- 아이콘 SVG 컴포넌트들 ---
 const BackIcon = () => (
-  <svg xmlns="http://www.w3.org/2000/svg" className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="h-6 w-6"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M15 19l-7-7 7-7"
+    />
   </svg>
 );
 
-const ALL_PAYMENT_METHODS = ['인생회복 소비쿠폰', '온누리 상품권', '제로페이', '카카오페이'];
+const ALL_PAYMENT_METHODS = [
+  "인생회복 소비쿠폰",
+  "온누리 상품권",
+  "제로페이",
+  "카카오페이",
+];
 
 export default function AddStore() {
   const navigate = useNavigate();
   
   // API 명세에 맞게 form 상태를 수정/확장합니다.
   const [form, setForm] = useState({
+<<<<<<< Updated upstream
     name: '',            // name
     category: '',        // category
     phoneNumber: '',     // phoneNumber
@@ -26,10 +43,36 @@ export default function AddStore() {
     image: null,         // shopImageUrl
   });
   
+=======
+    name: "",
+    image: null,
+    category: "",
+    address: "",
+    phone: "",
+    hours: "",
+    paymentMethods: [],
+  });
+
+  const handlePaymentChange = (method) => {
+    setForm((prev) => {
+      const currentMethods = prev.paymentMethods;
+      if (currentMethods.includes(method)) {
+        return {
+          ...prev,
+          paymentMethods: currentMethods.filter((item) => item !== method),
+        };
+      } else {
+        return { ...prev, paymentMethods: [...currentMethods, method] };
+      }
+    });
+  };
+
+>>>>>>> Stashed changes
   const handleChange = (e) => {
     const { name, value } = e.target;
-    setForm(prev => ({ ...prev, [name]: value }));
+    setForm((prev) => ({ ...prev, [name]: value }));
   };
+<<<<<<< Updated upstream
   
   // handleSubmit 함수를 API 요청을 보내는 비동기 함수로 변경합니다.
   const handleSubmit = async () => {
@@ -85,6 +128,14 @@ export default function AddStore() {
       console.error('가게 등록 실패:', error);
       alert('가게 등록에 실패했습니다. 다시 시도해주세요.');
     }
+=======
+
+  const handleSubmit = () => {
+    // TODO: 유효성 검사 추가
+    console.log("등록할 가게 정보:", form);
+    alert("가게 정보가 등록되었습니다! (콘솔 확인)");
+    navigate(`/store?marketId=${marketId}&shopId=${newShopId}`); // 등록 후 가게 상세 페이지로 이동
+>>>>>>> Stashed changes
   };
 
   return (
@@ -93,28 +144,67 @@ export default function AddStore() {
         <button onClick={() => navigate(-1)} className="p-1">
           <BackIcon />
         </button>
-        <h1 className="text-lg font-bold text-center flex-grow">내 가게 정보 등록</h1>
+        <h1 className="text-lg font-bold text-center flex-grow">
+          내 가게 정보 등록
+        </h1>
         <div className="w-6" />
       </header>
 
       <main className="flex-1 overflow-y-auto p-6 bg-gray-50">
         <div className="space-y-6">
+<<<<<<< Updated upstream
           {/* 가게 이름 */}
+=======
+>>>>>>> Stashed changes
           <div className="bg-white p-4 rounded-lg shadow-sm">
-            <label htmlFor="name" className="block text-sm font-bold text-gray-800 mb-2">가게 이름</label>
-            <input id="name" name="name" value={form.name} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm" placeholder="예: 동산족발" />
+            <label
+              htmlFor="name"
+              className="block text-sm font-bold text-gray-800 mb-2"
+            >
+              가게 이름
+            </label>
+            <input
+              id="name"
+              name="name"
+              value={form.name}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 px-3 py-2 text-sm"
+              placeholder="예: 동산족발"
+            />
           </div>
 
           {/* 가게 대표 이미지 */}
           <div className="bg-white p-4 rounded-lg shadow-sm">
-            <SingleImageUploader onFileChange={(file) => setForm(p => ({...p, image: file}))} label="가게 대표 이미지" />
+            <SingleImageUploader
+              onFileChange={(file) => setForm((p) => ({ ...p, image: file }))}
+              label="가게 대표 이미지"
+            />
           </div>
 
           {/* 카테고리 */}
           <div className="bg-white p-4 rounded-lg shadow-sm">
+<<<<<<< Updated upstream
             <label htmlFor="category" className="block text-sm font-bold text-gray-800 mb-2">카테고리</label>
             <select id="category" name="category" value={form.category} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm">
               <option value="">가게 종류 선택</option>
+=======
+            <label
+              htmlFor="category"
+              className="block text-sm font-bold text-gray-800 mb-2"
+            >
+              카테고리
+            </label>
+            <select
+              id="category"
+              name="category"
+              value={form.category}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 px-3 py-2 text-sm"
+            >
+              <option value="" disabled>
+                가게 종류 선택
+              </option>
+>>>>>>> Stashed changes
               <option value="한식">한식</option>
               <option value="중식">중식</option>
               <option value="일식">일식</option>
@@ -125,6 +215,7 @@ export default function AddStore() {
 
           {/* 가게 주소 */}
           <div className="bg-white p-4 rounded-lg shadow-sm">
+<<<<<<< Updated upstream
             <label htmlFor="address" className="block text-sm font-bold text-gray-800 mb-2">가게 주소</label>
             <input id="address" name="address" value={form.address} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm" placeholder="예: 전남 여수시 시교4길 8-3" />
           </div>
@@ -133,10 +224,27 @@ export default function AddStore() {
           <div className="bg-white p-4 rounded-lg shadow-sm">
             <label htmlFor="floor" className="block text-sm font-bold text-gray-800 mb-2">층 / 호수</label>
             <input id="floor" name="floor" value={form.floor} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm" placeholder="예: 1층 A-02호" />
+=======
+            <label
+              htmlFor="address"
+              className="block text-sm font-bold text-gray-800 mb-2"
+            >
+              가게 주소
+            </label>
+            <input
+              id="address"
+              name="address"
+              value={form.address}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 px-3 py-2 text-sm"
+              placeholder="예: 전남 여수시 시교4길 8-3"
+            />
+>>>>>>> Stashed changes
           </div>
 
           {/* 전화번호 */}
           <div className="bg-white p-4 rounded-lg shadow-sm">
+<<<<<<< Updated upstream
             <label htmlFor="phoneNumber" className="block text-sm font-bold text-gray-800 mb-2">전화번호</label>
             <input id="phoneNumber" name="phoneNumber" type="tel" value={form.phoneNumber} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm" placeholder="예: 061-642-7089" />
           </div>
@@ -151,12 +259,72 @@ export default function AddStore() {
           <div className="bg-white p-4 rounded-lg shadow-sm">
             <label htmlFor="description" className="block text-sm font-bold text-gray-800 mb-2">가게 설명</label>
             <textarea id="description" name="description" value={form.description} onChange={handleChange} className="w-full rounded-md border-gray-300 px-3 py-2 text-sm h-24 resize-none" placeholder="손님들에게 보여질 가게 설명을 적어주세요." />
+=======
+            <label
+              htmlFor="phone"
+              className="block text-sm font-bold text-gray-800 mb-2"
+            >
+              전화번호
+            </label>
+            <input
+              id="phone"
+              name="phone"
+              type="tel"
+              value={form.phone}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 px-3 py-2 text-sm"
+              placeholder="예: 061-642-7089"
+            />
+          </div>
+
+          <div className="bg-white p-4 rounded-lg shadow-sm">
+            <label
+              htmlFor="hours"
+              className="block text-sm font-bold text-gray-800 mb-2"
+            >
+              영업시간
+            </label>
+            <textarea
+              id="hours"
+              name="hours"
+              value={form.hours}
+              onChange={handleChange}
+              className="w-full rounded-md border-gray-300 px-3 py-2 text-sm h-20 resize-none"
+              placeholder="예: 매일 10:00 - 22:00&#10;매주 월요일 휴무"
+            />
+          </div>
+
+          <div className="bg-white p-4 rounded-lg shadow-sm">
+            <label className="block text-sm font-bold text-gray-800 mb-2">
+              결제수단 (중복 선택 가능)
+            </label>
+            <div className="grid grid-cols-2 gap-2">
+              {ALL_PAYMENT_METHODS.map((method) => (
+                <label
+                  key={method}
+                  className="flex items-center space-x-2 text-sm"
+                >
+                  <input
+                    type="checkbox"
+                    checked={form.paymentMethods.includes(method)}
+                    onChange={() => handlePaymentChange(method)}
+                    className="rounded"
+                  />
+                  <span>{method}</span>
+                </label>
+              ))}
+            </div>
+>>>>>>> Stashed changes
           </div>
         </div>
       </main>
 
       <footer className="p-4 border-t bg-white flex-shrink-0">
-        <button type="button" onClick={handleSubmit} className="w-full rounded-lg bg-indigo-600 text-white py-3 text-sm font-bold hover:bg-indigo-700 transition-colors">
+        <button
+          type="button"
+          onClick={handleSubmit}
+          className="w-full rounded-lg bg-indigo-600 text-white py-3 text-sm font-bold hover:bg-indigo-700 transition-colors"
+        >
           가게 정보 등록하기
         </button>
       </footer>

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,15 +1,109 @@
-import React, { useState } from "react";
-import { Link } from "react-router-dom";
-import MarketSelectModal from "../components/modals/MarketSelectModal";
+// src/pages/MainPage.jsx
+import React, { useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import marketImg from "../assets/korean-market-storefront.png";
+import useAdminMode from "../hooks/useAdminMode";
+import ModeToggle from "../components/ModeToggle";
+
+const MY_MARKETS_KEY = "myMarkets";
+const readMyMarkets = () => {
+  try {
+    const arr = JSON.parse(localStorage.getItem(MY_MARKETS_KEY) || "[]");
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+};
 
 export default function MainPage() {
-  const [market, setMarket] = useState("여수 서시장");
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [notifOpen, setNotifOpen] = useState(false);
+  const { mode, isAdmin, toggle } = useAdminMode();
+
+  const [market, setMarket] = useState(
+    () => localStorage.getItem("currentMarketName") || ""
+  );
+  const [myMarkets, setMyMarkets] = useState(() => readMyMarkets());
   const [open, setOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  // 라우트 변경 시(시장 설정에서 돌아온 직후 포함) 최신값 동기화
+  useEffect(() => {
+    setMarket(localStorage.getItem("currentMarketName") || "");
+    setMyMarkets(readMyMarkets());
+  }, [location.pathname, location.search]);
+
+  // 포커스/스토리지 동기화(다른 탭 대비)
+  useEffect(() => {
+    const sync = () => {
+      setMarket(localStorage.getItem("currentMarketName") || "");
+      setMyMarkets(readMyMarkets());
+    };
+    window.addEventListener("focus", sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener("focus", sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  // 외부 클릭으로 드롭다운 닫기
+  useEffect(() => {
+    const onClickOutside = (e) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(e.target)) setOpen(false);
+    };
+    if (open) document.addEventListener("mousedown", onClickOutside);
+    return () => document.removeEventListener("mousedown", onClickOutside);
+  }, [open]);
+
+  function goMarketSetting() {
+    setOpen(false);
+    navigate("/market-setting");
+  }
+
+  // 드롭다운 열 때 최신 목록 재읽기
+  function toggleMenu() {
+    if (!open) setMyMarkets(readMyMarkets());
+    setOpen((v) => !v);
+  }
+
+  // “선택”: 현재 시장 지정
+  function chooseMarket(m) {
+    localStorage.setItem("currentMarketName", m.name);
+    if (m.id) localStorage.setItem("currentMarketId", m.id);
+    if (m.lat) localStorage.setItem("currentMarketLat", String(m.lat));
+    if (m.lng) localStorage.setItem("currentMarketLng", String(m.lng));
+    setMarket(m.name);
+    setOpen(false);
+  }
+
+  // 선택만 해제(저장 목록은 유지)
+  function clearSelection() {
+    localStorage.removeItem("currentMarketName");
+    localStorage.removeItem("currentMarketId");
+    localStorage.removeItem("currentMarketLat");
+    localStorage.removeItem("currentMarketLng");
+    setMarket("");
+    setOpen(false);
+  }
 
   const popular = [
-    { name: "숙이 떡집", desc: "전통 떡과 한과 전문점", distance: "1.4km", open: true, emoji: "🍡" },
-    { name: "돌산 족발", desc: "신선한 족발과 보쌈 전문", distance: "1.2km", open: true, emoji: "🍖" },
+    {
+      name: "숙이 떡집",
+      desc: "전통 떡과 한과 전문점",
+      distance: "1.4km",
+      open: true,
+      emoji: "🍡",
+    },
+    {
+      name: "돌산 족발",
+      desc: "신선한 족발과 보쌈 전문",
+      distance: "1.2km",
+      open: true,
+      emoji: "🍖",
+    },
   ];
   const categories = [
     { name: "숙이 떡집", emoji: "🍡", bg: "bg-orange-100" },
@@ -22,30 +116,121 @@ export default function MainPage() {
     { name: "수산물", emoji: "🐟", bg: "bg-cyan-100" },
     { name: "정육점", emoji: "🥩", bg: "bg-rose-200" },
   ];
-  const markets = ["여수 서시장", "여수 수산시장"];
 
   return (
-    // 최상위 div를 flex 컨테이너로 만들어 헤더와 메인 영역을 분리합니다.
     <div className="flex flex-col h-full">
-      {/* 헤더: 이 부분은 스크롤되지 않고 상단에 고정됩니다. */}
+      {/* 헤더 */}
       <header
-        className="px-4 pt-12 pb-6 text-white flex-shrink-0" // flex-shrink-0 추가
+        className="px-4 pt-12 pb-6 text-white flex-shrink-0"
         style={{ backgroundColor: "#93DA97" }}
       >
-        <div className="flex items-center justify-between mb-3.5">
-          <button className="inline-flex items-center justify-center size-8 rounded-full bg-white/20">
-            🔔
-          </button>
-          <button
-            onClick={() => setOpen(true)}
-            className="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-3 py-1.5 text-emerald-800 font-bold"
+        <div className="relative flex items-center justify-between mb-3.5">
+          {/* 알림 버튼 */}
+          <div className="relative">
+            <button
+              onClick={() => setNotifOpen((o) => !o)}
+              className="inline-flex items-center justify-center size-8 rounded-full bg-white/20 shrink-0
+                transition-transform duration-150 active:scale-95 focus:outline-none
+                focus:ring-2 focus:ring-white/50"
+              aria-expanded={notifOpen}
+              aria-haspopup="true"
+              aria-label="알림 열기"
+            >
+              🔔
+            </button>
+
+            <div
+              className={`absolute left-0 mt-2 w-56 rounded-lg bg-white shadow-lg ring-1 ring-black/5
+              p-3 text-sm text-slate-700 text-center z-40
+              transform transition-all duration-200 ease-out origin-top-left
+              ${
+                notifOpen
+                  ? "opacity-100 translate-x-0 translate-y-0 scale-100"
+                  : "opacity-0 -translate-x-2 -translate-y-2 scale-95 pointer-events-none"
+              }`}
+            >
+              현재 알림이 없습니다.
+            </div>
+          </div>
+
+          {/* 가운데 절대 배치: 버튼이 항상 정확히 중앙에 고정 */}
+          <div
+            className="absolute left-1/2 -translate-x-1/2 z-30"
+            ref={menuRef}
           >
-            {market} ▾
-          </button>
-          <button className="inline-flex items-center justify-center size-8 rounded-full bg-white/20">
-            MY
-          </button>
+            <button
+              onClick={toggleMenu}
+              className="inline-flex items-center gap-1.5 rounded-full bg-white/95 px-3 py-1.5
+                text-emerald-800 font-bold transition-transform duration-150
+                active:scale-95 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+              aria-expanded={open}
+              aria-haspopup="true"
+            >
+              {market || "시장 선택"} ▾
+            </button>
+
+            <div
+              className={`absolute left-1/2 -translate-x-1/2 mt-2 w-56 rounded-xl bg-white shadow-lg
+            ring-1 ring-black/5 p-1 z-40 text-slate-900
+            transform transition-all duration-300 ease-out origin-top
+            ${
+              open
+                ? "opacity-100 translate-y-0 scale-100"
+                : "opacity-0 -translate-y-1 scale-95 pointer-events-none"
+            }`}
+              aria-hidden={!open}
+              style={{ willChange: "transform, opacity" }} /* 부드럽게 */
+            >
+              {/* 저장된 시장 목록 / 비어있으면 안내 */}
+              <div className="px-3 py-2 text-xs text-gray-500">저장된 시장</div>
+
+              {myMarkets.length === 0 ? (
+                <div className="px-3 py-2 text-sm text-gray-500 text-center">
+                  저장된 시장이 없습니다
+                </div>
+              ) : (
+                myMarkets.map((m) => (
+                  <button
+                    key={m.id ?? `${m.name}-${m.lat},${m.lng}`}
+                    onClick={() => chooseMarket(m)}
+                    className="w-full text-left px-3 py-2 rounded-lg hover:bg-gray-50 flex items-center justify-between"
+                  >
+                    <span>{m.name}</span>
+                    {market === m.name && (
+                      <span className="text-emerald-600 text-xs font-bold">
+                        선택됨
+                      </span>
+                    )}
+                  </button>
+                ))
+              )}
+
+              <div className="my-1 h-px bg-gray-200" />
+
+              {market && (
+                <button
+                  onClick={clearSelection}
+                  className="w-full text-left px-3 py-2 rounded-lg hover:bg-gray-50 text-rose-600"
+                >
+                  선택 해제
+                </button>
+              )}
+
+              <button
+                onClick={goMarketSetting}
+                className="w-full text-left px-3 py-2 rounded-lg hover:bg-gray-50"
+              >
+                시장 찾기/추가하기
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 shrink-0">
+            {/* 관리자 ↔ 사용자 토글 */}
+            <ModeToggle mode={mode} onToggle={toggle} />
+          </div>
         </div>
+
         <div className="relative">
           <span className="absolute left-3 top-1/2 -translate-y-1/2 opacity-50">
             🔎
@@ -56,8 +241,7 @@ export default function MainPage() {
           />
         </div>
       </header>
-
-      {/* 메인 콘텐츠: 이 부분만 스크롤됩니다. */}
+      {/* 메인 콘텐츠 */}
       <main className="flex-1 overflow-y-auto p-4 space-y-6">
         <section>
           <div className="rounded-2xl overflow-hidden shadow relative h-[160px]">
@@ -70,70 +254,107 @@ export default function MainPage() {
           </div>
         </section>
 
-        {/* 자주 찾는 가게 */}
-        <section>
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="font-extrabold text-[16px]">자주 찾는 가게</h3>
-            <Link to="/store" className="px-2 py-1 rounded-md font-bold text-emerald-700 hover:bg-emerald-50">
-              전체보기
-            </Link>
-          </div>
-          <div className="grid grid-cols-2 gap-[14px]">
-            {popular.map((s) => (
-              <Link
-                to="/store"
-                key={s.name}
-                className="block rounded-[18px] bg-white shadow p-3.5 hover:bg-gray-50 transition-colors"
-              >
-                <div className="w-12 h-12 rounded-[14px] bg-rose-50 flex items-center justify-center mb-2.5">
-                  <span className="text-[22px]">{s.emoji}</span>
-                </div>
-                <div className="font-extrabold mb-1">{s.name}</div>
-                <div className="text-[13px] text-slate-500 leading-[1.35] h-[34px] overflow-hidden">
-                  {s.desc}
-                </div>
-                <div className="flex items-center gap-2 text-[12px] text-slate-500 mt-2">
-                  <span>{s.distance}</span>
-                  {s.open && (
-                    <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 text-emerald-600 font-bold px-2 py-0.5">
-                      <span className="inline-block size-2 rounded-full bg-emerald-500" />
-                      현재 영업중
-                    </span>
-                  )}
-                </div>
-              </Link>
-            ))}
-          </div>
-        </section>
-
-        {/* 카테고리 */}
-        <section>
-          <h3 className="font-extrabold text-[16px] mb-3">카테고리</h3>
-          <div className="grid grid-cols-3 gap-3">
-            {categories.map((c) => (
-              <div key={c.name} className="rounded-2xl shadow p-3 text-center">
-                <div
-                  className={`w-11 h-11 rounded-xl mx-auto mb-2 flex items-center justify-center ${c.bg}`}
-                >
-                  <span className="text-[20px]">{c.emoji}</span>
-                </div>
-                <div className="text-[14px] font-bold text-slate-900">
-                  {c.name}
-                </div>
+        {!market ? (
+          <section className="flex items-center justify-center py-8">
+            <div className="mx-auto max-w-[360px] rounded-2xl border p-4 text-center">
+              <div className="font-bold mb-1">
+                아직 시장이 선택되지 않았어요
               </div>
-            ))}
-          </div>
-        </section>
-      </main>
+              <div className="text-sm text-slate-600 mb-3">
+                먼저 내 주변 시장을 선택하면 가게/상품을 추천해 드릴게요.
+              </div>
+              <button
+                onClick={goMarketSetting}
+                className="px-4 py-2 rounded-lg bg-[#93DA97] text-black font-semibold block mx-auto
+                  hover:bg-[#7ecb82] transition-colors"
+              >
+                내 시장 추가하러 가기
+              </button>
+            </div>
+          </section>
+        ) : (
+          <>
+            {/* 자주 찾는 가게 */}
+            <section>
+              <div className="flex items-center justify-between mb-3">
+                <h3 className="font-extrabold text-[16px]">자주 찾는 가게</h3>
+                <Link
+                  to="/store"
+                  className="px-2 py-1 rounded-md font-bold text-emerald-700 hover:bg-emerald-50"
+                >
+                  전체보기
+                </Link>
+              </div>
+              <div className="grid grid-cols-2 gap-[14px]">
+                {popular.map((s) => (
+                  <Link
+                    to="/store"
+                    key={s.name}
+                    className="block rounded-[18px] bg-white shadow p-3.5 hover:bg-gray-50 transition-colors"
+                  >
+                    <div className="w-12 h-12 rounded-[14px] bg-rose-50 flex items-center justify-center mb-2.5">
+                      <span className="text-[22px]">{s.emoji}</span>
+                    </div>
+                    <div className="font-extrabold mb-1">{s.name}</div>
+                    <div className="text-[13px] text-slate-500 leading-[1.35] h-[34px] overflow-hidden">
+                      {s.desc}
+                    </div>
+                    <div className="flex items-center gap-2 text-[12px] text-slate-500 mt-2">
+                      <span>{s.distance}</span>
+                      {s.open && (
+                        <span className="inline-flex items-center gap-1.5 rounded-full bg-emerald-50 text-emerald-600 font-bold px-2 py-0.5">
+                          <span className="inline-block size-2 rounded-full bg-emerald-500" />
+                          현재 영업중
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            </section>
 
-      {/* 모달 */}
-      <MarketSelectModal
-        open={open}
-        markets={markets}
-        current={market}
-        onSelect={setMarket}
-        onClose={() => setOpen(false)}
-      />
+            {/* 카테고리 */}
+            <section>
+              <h3 className="font-extrabold text-[16px] mb-3">카테고리</h3>
+              <div className="grid grid-cols-3 gap-3">
+                {categories.map((c) => (
+                  <div
+                    key={c.name}
+                    className="rounded-2xl shadow p-3 text-center"
+                  >
+                    <div
+                      className={`w-11 h-11 rounded-xl mx-auto mb-2 flex items-center justify-center ${c.bg}`}
+                    >
+                      <span className="text-[20px]">{c.emoji}</span>
+                    </div>
+                    <div className="text-[14px] font-bold text-slate-900">
+                      {c.name}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </>
+        )}
+      </main>
+      {/* 관리자 모드에서만: 우하단 FAB */}
+      {isAdmin && (
+        <button
+          onClick={() => navigate("/add-product")}
+          className="absolute w-14 h-14 rounded-full shadow-xl active:scale-95"
+          style={{
+            backgroundColor: "#93DA97",
+            right: "20px", // 스마트폰 프레임 내부에서 20px 띄움
+            bottom: "24px", // 프레임 하단에서 24px 위
+          }}
+          aria-label="상품 등록"
+          title="상품 등록"
+        >
+          <span className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 text-white text-3xl font-bold">
+            +
+          </span>
+        </button>
+      )}
     </div>
   );
 }

--- a/src/pages/MarketSettingPage.jsx
+++ b/src/pages/MarketSettingPage.jsx
@@ -1,41 +1,284 @@
-import React from "react";
+// src/pages/MarketSettingPage.jsx
+import React, { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { loadKakaoMap } from "../lib/kakaoMapLoader";
+
+const FALLBACK_CENTER = { lat: 36.7794, lng: 127.0036 }; // 지오로케이션 실패 시
+const MY_MARKETS_KEY = "myMarkets";
+
+const readMyMarkets = () => {
+  try {
+    const arr = JSON.parse(localStorage.getItem(MY_MARKETS_KEY) || "[]");
+    return Array.isArray(arr) ? arr : [];
+  } catch {
+    return [];
+  }
+};
+const writeMyMarkets = (arr) =>
+  localStorage.setItem(MY_MARKETS_KEY, JSON.stringify(arr));
+const toEntry = (m) => ({
+  id: m.id || `${m.lat},${m.lng}`,
+  name: m.name,
+  addr: m.addr,
+  lat: m.lat,
+  lng: m.lng,
+});
 
 export default function MarketSettingPage() {
   const navigate = useNavigate();
-  const popular = [
-    { name: "신기종합시장", addr: "여수 신기동", reviews: 25 },
-    { name: "신기제일시장", addr: "여수 신기동", reviews: 27 },
-  ];
+
+  const mapRef = useRef(null);
+  const mapObj = useRef(null);
+  const markersRef = useRef([]);
+  const overlayRef = useRef(null); // 커스텀 말풍선 (재사용 1개)
+
+  const [results, setResults] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [savedIds, setSavedIds] = useState(() =>
+    readMyMarkets().map((m) => m.id)
+  );
+  const [flash, setFlash] = useState(null); // { id, mode: 'added'|'removed' }
+
+  useEffect(() => {
+    let canceled = false;
+
+    async function init() {
+      try {
+        const kakao = await loadKakaoMap();
+
+        // 1) 현재 위치
+        const center = await new Promise((resolve) => {
+          if (!navigator.geolocation) return resolve(FALLBACK_CENTER);
+          navigator.geolocation.getCurrentPosition(
+            ({ coords }) =>
+              resolve({ lat: coords.latitude, lng: coords.longitude }),
+            () => resolve(FALLBACK_CENTER),
+            { enableHighAccuracy: true, timeout: 4000 }
+          );
+        });
+        if (canceled) return;
+
+        // 2) 지도 생성
+        const mapCenter = new kakao.maps.LatLng(center.lat, center.lng);
+        const map = new kakao.maps.Map(mapRef.current, {
+          center: mapCenter,
+          level: 4,
+        });
+        mapObj.current = map;
+
+        // 내 위치 마커
+        new kakao.maps.Marker({ position: mapCenter }).setMap(map);
+
+        // ✅ 커스텀 오버레이 생성(가운데 정렬)
+        overlayRef.current = new kakao.maps.CustomOverlay({
+          xAnchor: 0.5, // 가로 중앙
+          yAnchor: 1.25, // 마커 위로 살짝
+        });
+
+        // 3) 주변 "시장" 키워드 검색
+        const ps = new kakao.maps.services.Places();
+        ps.keywordSearch(
+          "시장",
+          (data, status) => {
+            if (canceled) return;
+            if (status !== kakao.maps.services.Status.OK) {
+              setResults([]);
+              setLoading(false);
+              return;
+            }
+
+            // 이전 마커 정리
+            markersRef.current.forEach((m) => m.setMap(null));
+            markersRef.current = [];
+
+            // 결과 매핑
+            const list = data.map((p) => ({
+              id: p.id,
+              name: p.place_name,
+              addr: p.road_address_name || p.address_name,
+              lat: parseFloat(p.y), // y=위도
+              lng: parseFloat(p.x), // x=경도
+            }));
+            setResults(list);
+
+            // 마커 생성 + 클릭 시 커스텀 말풍선 열기
+            list.forEach((p) => {
+              const marker = new kakao.maps.Marker({
+                position: new kakao.maps.LatLng(p.lat, p.lng),
+                title: p.name,
+              });
+              marker.setMap(map);
+
+              kakao.maps.event.addListener(marker, "click", () => {
+                if (!overlayRef.current) return;
+                overlayRef.current.setContent(bubbleHTML(p.name));
+                overlayRef.current.setPosition(marker.getPosition());
+                overlayRef.current.setMap(map);
+              });
+
+              markersRef.current.push(marker);
+            });
+
+            setLoading(false);
+          },
+          { location: mapCenter, radius: 4000 }
+        );
+      } catch (e) {
+        console.error(e);
+        setLoading(false);
+      }
+    }
+
+    init();
+    return () => {
+      canceled = true;
+      markersRef.current.forEach((m) => m.setMap(null));
+      markersRef.current = [];
+      if (overlayRef.current) overlayRef.current.setMap(null);
+      mapObj.current = null;
+    };
+  }, []);
+
+  // 목록에서 클릭 시: 지도 이동 + 해당 마커 기준으로 말풍선 열기
+  function panTo(m) {
+    const kakao = window.kakao;
+    const map = mapObj.current;
+    if (!map) return;
+
+    const pos = new kakao.maps.LatLng(m.lat, m.lng);
+    map.relayout();
+    map.setCenter(pos);
+
+    const marker = markersRef.current.find(
+      (mk) => mk.getTitle && mk.getTitle() === m.name
+    );
+    if (marker && overlayRef.current) {
+      overlayRef.current.setContent(bubbleHTML(m.name));
+      overlayRef.current.setPosition(marker.getPosition());
+      overlayRef.current.setMap(map);
+    }
+  }
+
+  // 저장 토글
+  function toggleSave(m) {
+    const id = m.id || `${m.lat},${m.lng}`;
+    const current = readMyMarkets();
+    const exists = current.some((x) => x.id === id);
+
+    if (exists) {
+      const next = current.filter((x) => x.id !== id);
+      writeMyMarkets(next);
+      setSavedIds(next.map((x) => x.id));
+      setFlash({ id, mode: "removed" });
+    } else {
+      const entry = toEntry(m);
+      const next = [entry, ...current.filter((x) => x.id !== id)].slice(0, 10);
+      writeMyMarkets(next);
+      setSavedIds(next.map((x) => x.id));
+      setFlash({ id, mode: "added" });
+    }
+    setTimeout(() => setFlash(null), 650);
+  }
 
   return (
-    <div className="max-w-[390px] mx-auto bg-white min-h-screen">
-      <div className="flex items-center gap-3 px-4 h-12">
-        <button onClick={() => navigate(-1)} className="text-2xl">
-          ✕
-        </button>
-        <h1 className="text-lg font-extrabold">시장 설정</h1>
-      </div>
-
-      <div className="h-[300px] bg-sky-200 flex items-center justify-center">
-        <span className="text-sky-900 font-bold">지도 영역</span>
-      </div>
-
-      <div className="p-4 space-y-3">
-        <h2 className="text-slate-800 font-extrabold mb-2">인근 시장</h2>
-        {popular.map((m) => (
+    <div className="w-full h-dvh bg-white flex flex-col overflow-hidden">
+      {/* 상단 풀블리드 컬러 헤더 (안전영역 대응) */}
+      <div
+        className="relative w-full text-white"
+        style={{
+          backgroundColor: "#93DA97",
+          paddingTop: "env(safe-area-inset-top)",
+        }}
+      >
+        <div className="h-14 flex items-center justify-center text-black">
+          <h1 className="text-lg font-extrabold">시장 설정</h1>
           <button
-            key={m.name}
-            className="w-full text-left rounded-xl border border-slate-200 p-3 hover:bg-slate-50"
-            onClick={() => navigate(-1)} // 선택 후 뒤로
+            onClick={() => navigate(-1)}
+            className="absolute right-4 top-1/2 -translate-y-1/2 text-2xl leading-none"
+            aria-label="닫기"
           >
-            <div className="font-bold">{m.name}</div>
-            <div className="text-sm text-slate-500">
-              리뷰 {m.reviews} · {m.addr}
-            </div>
+            ✕
           </button>
-        ))}
+        </div>
+      </div>
+      {/* 지도 */}
+      <div ref={mapRef} className="h-[360px] bg-gray-100 shrink-0" />
+      {/* 인근 시장 목록 */}
+      <div className="flex-1 overflow-y-auto overscroll-contain p-4 space-y-2">
+        <h2 className="text-slate-900 font-extrabold mb-2">인근 시장</h2>
+        {loading && (
+          <div className="text-sm text-slate-500">주변 시장을 찾는 중…</div>
+        )}
+        {!loading && results.length === 0 && (
+          <div className="text-sm text-slate-500">
+            주변에서 시장을 찾지 못했어요.
+          </div>
+        )}
+
+        {results.map((m) => {
+          const id = m.id || `${m.lat},${m.lng}`;
+          const isSaved = savedIds.includes(id);
+          const isFlash = flash?.id === id;
+          const flashRing =
+            isFlash && flash.mode === "added"
+              ? "ring-2 ring-emerald-500"
+              : isFlash && flash.mode === "removed"
+              ? "ring-2 ring-rose-400"
+              : "";
+
+          return (
+            <div
+              key={id}
+              className={`rounded-xl border p-3 transition ${flashRing}`}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div onClick={() => panTo(m)} className="flex-1 cursor-pointer">
+                  <div className="font-bold text-emerald-700">{m.name}</div>
+                  <div className="text-sm text-slate-500">
+                    {m.addr || "주소 없음"}
+                  </div>
+                </div>
+
+                <button
+                  onClick={() => toggleSave(m)}
+                  className={`whitespace-nowrap px-3 py-1.5 rounded-lg font-semibold transition active:scale-95
+                    ${
+                      isSaved
+                        ? "bg-emerald-600 text-white"
+                        : "bg-white border hover:bg-emerald-50"
+                    }
+                    ${isFlash ? "animate-pulse" : ""}`}
+                >
+                  {isSaved ? "추가됨 ✓" : "추가하기"}
+                </button>
+              </div>
+            </div>
+          );
+        })}
       </div>
     </div>
   );
+}
+
+/** 말풍선 HTML (텍스트 길이만큼 가변, 정확히 중앙 정렬) */
+function bubbleHTML(text) {
+  // inline-block이라 내용 길이에 맞게 폭이 줄고,
+  // CustomOverlay의 xAnchor=0.5로 마커 기준 정확히 가운데에 위치합니다.
+  return `
+    <div style="position:relative; display:inline-block; background:#fff; border:1px solid #cfd4dc;
+                border-radius:8px; padding:6px 10px; font-weight:700; white-space:nowrap;
+                box-shadow:0 1px 6px rgba(0,0,0,.08);">
+      ${escapeHtml(text)}
+      <div style="position:absolute; left:50%; transform:translateX(-50%); bottom:-6px; width:0; height:0;
+                  border-left:6px solid transparent; border-right:6px solid transparent; border-top:6px solid #fff;
+                  filter: drop-shadow(0 -1px 0 rgba(0,0,0,.15));"></div>
+    </div>`;
+}
+
+// 안전하게 텍스트 삽입
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }


### PR DESCRIPTION
## 작업 내용
### 1. 사용자 / 관리자 모드 전환
- 오른쪽 상단에 토글을 만들어서 사용자 <-> 관리자 전환 가능 (심사 편의)
- 관리자 상태에서는 오른쪽 아래에 메뉴 추가할 수 있는 버튼 표시
- 버튼 누를 시 상품 등록 페이지로 라우팅

### 2. 지도
- 시장을 누르면 지도에서 해당 위치로 이동하여 마커 위에 시장명 표시
- 시장 설정 페이지에서 시장 선택 후, 메인화면 상단 시장 선택 드롭다운 버튼 누르면 선택한 시장 표시